### PR TITLE
Allow course id to be a thesis identifier

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -171,7 +171,7 @@ fn parse_course_results(results_html: &str) -> Vec<CourseResult> {
     let table_rows_selector = Selector::parse("table tr").unwrap();
     let cell_selector = Selector::parse("td").unwrap();
     let h1_selector = Selector::parse("h1").unwrap();
-    let course_id_regex = Regex::new(r"[A-Z0-9]+[0-9]{4}(\.[0-9]{1,2})?").unwrap();
+    let course_id_regex = Regex::new(r"[A-Z0-9]+[0-9]{4}(\.[0-9]{1,2})?|([A-Z][0-9]_[0-9]{4})").unwrap();
 
     let document = Html::parse_document(results_html);
     let mut results = Vec::new();


### PR DESCRIPTION
Thesis identifiers generally follow a different schema from course ids and are usually `<W or T for economy or tech><version number I guess>_<year of study><unique number for thesis type>`.

Notable examples are `T3_2000` for the second tech thesis and `T3_3300` for the bachelor's thesis.

This would otherwise panic because the result gets unwrapped.

---

On a different note you might want to add some topics to this repository, so it's easier to discover :)
I think there's a bit too many unwraps, but that's ok for such a project and the important thing is that it holds what it promises :+1: