### PR TITLE
Implement support for split single courses

### DIFF
--- a/src/results.rs
+++ b/src/results.rs
@@ -65,6 +65,9 @@ pub fn diff_results<'a>(old: &[CourseResult], new: &'a [CourseResult]) -> Vec<&'
             .iter()
             .find(|old_entry| old_entry.course_id == entry.course_id);
         if old_entry.is_none() {
+            if entry.scored {
+                changed.push(entry);
+            }
             continue;
         }
 

--- a/test_data/result_details_single_split.html
+++ b/test_data/result_details_single_split.html
@@ -1,0 +1,66 @@
+<h1>T3INF4303&nbsp;Computergraphik und Bildverarbeitung (SoSe 2022)</h1>
+
+<table class="tb" style="width:700px;">
+  <tr><td class="tbhead" colspan="7">&nbsp;</td></tr>
+  <tr>
+    <td class="tbsubhead">Versuch</td>
+    <td class="tbsubhead">&nbsp;</td>
+    <td class="tbsubhead">Prüfung</td>
+    <td class="tbsubhead">Datum</td>
+    <td class="tbsubhead">Bewertung</td>
+    <td class="tbsubhead">Extern anerkannt</td>
+    <td class="tbsubhead">&nbsp;</td>
+  </tr>
+  <tr>
+    <td class="level01" colspan="5">Versuch  1</td>
+    <td class="level01">&nbsp;</td>
+    <td class="level01"></td>
+  </tr>
+
+  <tr>
+    <td class="level02" colspan="8">Modulabschlussleistungen</td>
+  </tr>
+
+  <!-- Anfang Teilpruefungen -->
+  <!-- Ende Teilpruefungen -->
+  <tr>
+    <td class="tbdata" colspan="2">SoSe 2022</td>
+    <td class="tbdata" >Klausur oder Kombinierte Prüfung (100%)</td>
+    <td class="tbdata" style="vertical-align:top;"></td>
+    <td class="tbdata" style="vertical-align:top;">2,3</td>
+    <td class="tbdata" style="text-align:center;"></td>
+
+    <td class="tbdata"></td>
+  </tr>
+
+  <!-- Anfang Teilpruefungen -->
+  <tr>
+    <td class="tbdata" colspan="2">&nbsp;</td>
+    <td class="tbdata">&nbsp;&nbsp;Digitale Bildverarbeitung - Klausur und Projekt(50%)</td>
+    <td class="tbdata">&nbsp;</td>
+    <td class="tbdata" style="vertical-align:top;"> 62,0</td>
+    <td class="tbdata" colspan="2">&nbsp;</td>
+    <td class="tbdata">&nbsp;</td>
+  </tr>
+  <tr>
+    <td class="tbdata" colspan="2">&nbsp;</td>
+    <td class="tbdata">&nbsp;&nbsp;Computergrafik(50%)</td>
+    <td class="tbdata">&nbsp;</td>
+    <td class="tbdata" style="vertical-align:top;"> 76,0</td>
+    <td class="tbdata" colspan="2">&nbsp;</td>
+    <td class="tbdata">&nbsp;</td>
+  </tr>
+  <!-- Ende Teilpruefungen -->
+
+  <tr>
+    <td class="level02">&nbsp;</td>
+    <td class="level02" style="white-space:nowrap;">Gesamt 1</td>
+    <td class="level02" colspan="2">&nbsp;</td>
+    <td class="level02" style="vertical-align:top;">2,3&nbsp;bestanden</td>
+    <td class="level02">&nbsp;</td>
+
+    <td class="level02">&nbsp;</td>
+  </tr>
+</table>
+
+


### PR DESCRIPTION
Split single courses are actually a lot more common than the multi-courses.

Since their grades are combined in the end by a weighted average, there will actually always be the complete grade for the course too.

So a course split into two parts will be reported as one main course and two subcourses.

This also changes the loading behavior a bit.
With these split courses it is pretty common that parts are only actually added to the tables when their grades are published.
Therefore, new courses that pop up and are already scored will now be detected as updates.

The included split course example is real (even the spelling inconsistency), but the grades are not ^^